### PR TITLE
Allow all gamepad devices for built-in `ui_*` input actions

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -1188,11 +1188,12 @@ String InputEventJoypadMotion::to_string() {
 	return vformat("InputEventJoypadMotion: axis=%d, axis_value=%.2f", axis, axis_value);
 }
 
-Ref<InputEventJoypadMotion> InputEventJoypadMotion::create_reference(JoyAxis p_axis, float p_value) {
+Ref<InputEventJoypadMotion> InputEventJoypadMotion::create_reference(JoyAxis p_axis, float p_value, int p_device) {
 	Ref<InputEventJoypadMotion> ie;
 	ie.instantiate();
 	ie->set_axis(p_axis);
 	ie->set_axis_value(p_value);
+	ie->set_device(p_device);
 
 	return ie;
 }
@@ -1307,10 +1308,11 @@ String InputEventJoypadButton::to_string() {
 	return vformat("InputEventJoypadButton: button_index=%d, pressed=%s, pressure=%.2f", button_index, p, pressure);
 }
 
-Ref<InputEventJoypadButton> InputEventJoypadButton::create_reference(JoyButton p_btn_index) {
+Ref<InputEventJoypadButton> InputEventJoypadButton::create_reference(JoyButton p_btn_index, int p_device) {
 	Ref<InputEventJoypadButton> ie;
 	ie.instantiate();
 	ie->set_button_index(p_btn_index);
+	ie->set_device(p_device);
 
 	return ie;
 }

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -339,7 +339,8 @@ public:
 	virtual String as_text() const override;
 	virtual String to_string() override;
 
-	static Ref<InputEventJoypadMotion> create_reference(JoyAxis p_axis, float p_value);
+	// The default device ID is `InputMap::ALL_DEVICES`.
+	static Ref<InputEventJoypadMotion> create_reference(JoyAxis p_axis, float p_value, int p_device = -1);
 
 	InputEventType get_type() const final override { return InputEventType::JOY_MOTION; }
 
@@ -371,7 +372,8 @@ public:
 	virtual String as_text() const override;
 	virtual String to_string() override;
 
-	static Ref<InputEventJoypadButton> create_reference(JoyButton p_btn_index);
+	// The default device ID is `InputMap::ALL_DEVICES`.
+	static Ref<InputEventJoypadButton> create_reference(JoyButton p_btn_index, int p_device = -1);
 
 	InputEventType get_type() const final override { return InputEventType::JOY_BUTTON; }
 

--- a/editor/settings/input_event_configuration_dialog.cpp
+++ b/editor/settings/input_event_configuration_dialog.cpp
@@ -527,10 +527,8 @@ void InputEventConfigurationDialog::_input_list_item_selected() {
 		} break;
 		case INPUT_JOY_BUTTON: {
 			JoyButton idx = (JoyButton)(int)selected->get_meta("__index");
-			Ref<InputEventJoypadButton> jb = InputEventJoypadButton::create_reference(idx);
-
 			// Maintain selected device
-			jb->set_device(_get_current_device());
+			Ref<InputEventJoypadButton> jb = InputEventJoypadButton::create_reference(idx, _get_current_device());
 
 			_set_event(jb, jb, false);
 		} break;


### PR DESCRIPTION
This allows all controllers to navigate the UI, which enhances compatibility with PC handhelds when external controllers are connected.

Previously, only the first device was allowed to use `ui_*` actions out of the box, which means that on a PC handheld, external controllers couldn't navigate the UI (since the first ID is always the built-in controller).

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
